### PR TITLE
Provide manual OBS setup instructions via tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbd-streak-overlay
 
-Electron application that connects to OBS through obs-websocket. It serves a dock UI for editing text and a browser source that displays the text. The dock and source communicate through a local WebSocket server. The app also checks GitHub for updates using `electron-updater`.
+Electron application that serves a dock UI for editing text and a browser source that displays the text. The dock and source communicate through a local WebSocket server. The app also checks GitHub for updates using `electron-updater`.
 
 ## Development
 
@@ -10,7 +10,7 @@ npm run build   # build dock and source pages into dist/
 npm start       # launch the electron app
 ```
 
-The app will attempt to create a browser source and custom dock in OBS using the built pages.
+When running, use the tray icon to open instructions. You will need to manually create a Browser Source and a Custom Browser Dock in OBS using the provided local URLs.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "electron-updater": "^6.1.1",
         "express": "^4.19.2",
-        "obs-websocket-js": "^5.0.4",
         "ws": "^8.16.0"
       },
       "devDependencies": {
@@ -429,15 +428,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@msgpack/msgpack": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
-      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1026,12 +1016,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1389,12 +1373,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/express": {
       "version": "4.21.2",
@@ -1828,15 +1806,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/isomorphic-ws": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2074,24 +2043,6 @@
       "optional": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/obs-websocket-js": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/obs-websocket-js/-/obs-websocket-js-5.0.6.tgz",
-      "integrity": "sha512-tHRq8py1XrdlMhSV+N/KTGHqoRIcsBBXbjcA9ex21k128iQ7YXjxzNWs3s9gidP1tEcIyVuJu8FnPgrSBWGm0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@msgpack/msgpack": "^2.7.1",
-        "crypto-js": "^4.1.1",
-        "debug": "^4.3.2",
-        "eventemitter3": "^5.0.1",
-        "isomorphic-ws": "^5.0.0",
-        "type-fest": "^3.11.0",
-        "ws": "^8.13.0"
-      },
-      "engines": {
-        "node": ">16.0"
       }
     },
     "node_modules/on-finished": {
@@ -2624,18 +2575,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "electron-updater": "^6.1.1",
     "express": "^4.19.2",
-    "obs-websocket-js": "^5.0.4",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/src/instructions.html
+++ b/src/instructions.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>DBD Streak Overlay Setup</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    code { background-color: #f0f0f0; padding: 2px 4px; }
+  </style>
+</head>
+<body>
+  <h1>DBD Streak Overlay</h1>
+  <p>To connect the overlay and editor in OBS, create the items manually using these URLs:</p>
+  <ol>
+    <li>Add a <strong>Browser Source</strong> with the URL <code>http://localhost:3000/source.html</code>.</li>
+    <li>Add a <strong>Custom Browser Dock</strong> with the URL <code>http://localhost:3000/dock.html</code>.</li>
+  </ol>
+</body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,8 @@
 import { defineConfig } from 'vite';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   root: 'src',
@@ -6,8 +10,9 @@ export default defineConfig({
     outDir: '../dist',
     rollupOptions: {
       input: {
-        dock: 'dock.html',
-        source: 'source.html'
+        dock: path.resolve(__dirname, 'src/dock.html'),
+        source: path.resolve(__dirname, 'src/source.html'),
+        instructions: path.resolve(__dirname, 'src/instructions.html')
       }
     }
   }


### PR DESCRIPTION
## Summary
- Remove automatic OBS integration and offer instructions through a tray menu
- Expose local overlay and dock URLs in an instructions page served by the app
- Document manual OBS setup steps in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68946339d998832993a2356e0cccfc71