### PR TITLE
feat: reload browser on source changes

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,8 @@ import express from 'express';
 import { WebSocketServer } from 'ws';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import chokidar from 'chokidar';
+import { exec } from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 3000;
@@ -35,6 +37,31 @@ wss.on('connection', ws => {
     }
   });
 });
+
+// Rebuild and reload clients on source changes during development
+if (!app.isPackaged) {
+  const build = reload => {
+    exec('npm run build', (err, stdout, stderr) => {
+      if (err) {
+        console.error(stderr || err);
+        return;
+      }
+      if (reload) {
+        wss.clients.forEach(client => {
+          client.send(JSON.stringify({ type: 'reload' }));
+        });
+      }
+    });
+  };
+
+  // Initial build without triggering a reload
+  build(false);
+
+  const watcher = chokidar.watch(path.join(__dirname, '../src'), {
+    ignoreInitial: true
+  });
+  watcher.on('all', () => build(true));
+}
 
 let instructionsWin;
 function createInstructionsWindow() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ws": "^8.16.0"
       },
       "devDependencies": {
+        "chokidar": "^4.0.3",
         "electron": "^30.0.1",
         "vite": "^5.4.6"
       }
@@ -965,6 +966,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/clone-response": {
@@ -2219,6 +2236,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/resolve-alpn": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ws": "^8.16.0"
   },
   "devDependencies": {
+    "chokidar": "^4.0.3",
     "electron": "^30.0.1",
     "vite": "^5.4.6"
   },

--- a/src/dock.js
+++ b/src/dock.js
@@ -3,6 +3,10 @@ const input = document.getElementById('text-input');
 
 ws.addEventListener('message', ev => {
   const data = JSON.parse(ev.data);
+  if (data.type === 'reload') {
+    location.reload();
+    return;
+  }
   if (data.type === 'update' && document.activeElement !== input) {
     input.value = data.text || '';
   }

--- a/src/source.js
+++ b/src/source.js
@@ -3,6 +3,10 @@ const display = document.getElementById('display');
 
 ws.addEventListener('message', ev => {
   const data = JSON.parse(ev.data);
+  if (data.type === 'reload') {
+    location.reload();
+    return;
+  }
   if (data.type === 'update') {
     display.textContent = data.text || '';
   }


### PR DESCRIPTION
## Summary
- rebuild assets and reload connected browsers when source files change
- refresh dock and overlay pages after reload messages

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68946d5118e48329b949e92e8998bc25